### PR TITLE
Increase safe obstacle distance to 1.5m

### DIFF
--- a/config/navigation.yaml
+++ b/config/navigation.yaml
@@ -1,7 +1,7 @@
 param_namespace:
   # planning
   euclidean_distance_cutoff: 2.0 # [m]
-  safe_obstacle_distance: 1.0 # [m]
+  safe_obstacle_distance: 1.5 # [m]
   unknown_is_occupied: false
   navigation_tolerance: 0.4 # [m]
   min_altitude: 1.0 # [m]


### PR DESCRIPTION
Safe obstacle distance is calculated from the center of the drone. This
is important to keep in mind when setting safe obstacle distance.