### PR TITLE
reduce safe obstacle distance

### DIFF
--- a/config/navigation.yaml
+++ b/config/navigation.yaml
@@ -1,6 +1,6 @@
 planning:
   euclidean_distance_cutoff: 3.0 # [m]
-  safe_obstacle_distance: 2.0 # [m]
+  safe_obstacle_distance: 1.0 # [m]
   bumper_distance_factor: 0.9 # virtual bumper will intervene at (safe_obstacle_distance * bumper_distance_factor)
   unknown_is_occupied: false
   navigation_tolerance: 0.4 # [m]


### PR DESCRIPTION
We reduce the safe obstacle distance so the drone doesn't steer too far
away, this sometimes results with the drone exiting the flight arena, or
getting stuck between obstacles far away from each other.

Co-authored-by: Humaid humaid@ssrc.tii.ae
Co-authored-by: Pedro pedro@ssrc.tii.ae