### PR TITLE
Fix sending multiple paths to control interface 

### DIFF
--- a/include/navigation/astar_planner.hpp
+++ b/include/navigation/astar_planner.hpp
@@ -77,7 +77,7 @@ private:
 
 public:
   std::pair<std::vector<octomap::point3d>, PlanningResult> findPath(
-      const octomap::point3d &start_coord, const octomap::point3d &goal_coord, std::shared_ptr<octomap::OcTree> mapping_tree,
+      const octomap::point3d &start_coord, const octomap::point3d &goal_coord, const octomap::point3d &pos_cmd, std::shared_ptr<octomap::OcTree> mapping_tree,
       double timeout, std::function<void(const octomap::OcTree &)> visualizeTree,
       std::function<void(const std::unordered_set<Node, HashFunction> &, const std::unordered_set<Node, HashFunction> &, const octomap::OcTree &)>
           visualizeExpansions);
@@ -108,7 +108,7 @@ private:
   std::optional<std::pair<octomap::OcTree, std::vector<octomap::point3d>>> createPlanningTree(std::shared_ptr<octomap::OcTree> tree,
                                                                                               const octomap::point3d &start, double resolution);
 
-  std::pair<octomap::point3d, bool> generateTemporaryGoal(const octomap::point3d &start, const octomap::point3d &goal, octomap::OcTree &tree);
+  std::pair<octomap::point3d, bool> generateTemporaryGoal(const octomap::point3d &start, const octomap::point3d &goal, const octomap::point3d &pos_cmd, octomap::OcTree &tree);
 
   std::vector<octomap::point3d> filterPath(const std::vector<octomap::point3d> &waypoints, octomap::OcTree &tree);
 

--- a/src/astar_planner.cpp
+++ b/src/astar_planner.cpp
@@ -540,8 +540,12 @@ std::pair<octomap::point3d, bool> AstarPlanner::generateTemporaryGoal(const octo
     temp_goal.y() = start.y();
     // temp_goal.z() = goal.z();  // scan new layers of octomap if needed
     
-    double alt_diff = pos_cmd.z() - start.z();  // odometry and desired altitude may differ
-    temp_goal.z()   = goal.z() + alt_diff;      // scan new layers of octomap in that case
+    double extra_motion = goal.z() - start.z();
+    extra_motion        = (extra_motion / std::abs(extra_motion)) * planning_tree_resolution;
+
+    // double alt_diff = pos_cmd.z() - start.z();  // odometry and desired altitude may differ
+
+    temp_goal.z()   = goal.z() + extra_motion;      // scan new layers of octomap in that case
 
     if (temp_goal.z() > max_altitude) {
       printf("[Astar]: capping at max altitude\n");

--- a/src/navigation.cpp
+++ b/src/navigation.cpp
@@ -1001,7 +1001,10 @@ void Navigation::navigationRoutine(void) {
         auto waypoints_srv = waypointsToPathSrv(waypoint_out_buffer_, false);
         auto call_result   = local_path_client_->async_send_request(waypoints_srv);
         status_            = MOVING;
-        diagnostics_received_ = false;
+        {
+          std::scoped_lock lock(control_diagnostics_mutex_);
+          diagnostics_received_ = false;
+        }
         break;
       }
         //}

--- a/src/navigation.cpp
+++ b/src/navigation.cpp
@@ -286,7 +286,7 @@ Navigation::Navigation(rclcpp::NodeOptions options) : Node("navigation", options
   current_waypoint_id_ = 0;
   bumper_msg_.reset();
 
-  callback_group_        = this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+  callback_group_        = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   auto sub_opt           = rclcpp::SubscriptionOptions();
   sub_opt.callback_group = callback_group_;
 

--- a/src/navigation.cpp
+++ b/src/navigation.cpp
@@ -861,7 +861,7 @@ void Navigation::navigationRoutine(void) {
                                      min_altitude_, max_altitude_, planning_timeout_, max_waypoint_distance_, unknown_is_occupied_);
 
         octomap::point3d planning_start = toPoint3d(uav_pos_);
-        //octomap::point3d pos_cmd        = toPoint3d(desired_pose_);
+        octomap::point3d pos_cmd        = toPoint3d(desired_pose_);
         /*if ((desired_pose_.head<3>() - uav_pos_.head<3>()).norm() <= navigation_tolerance_) {
           planning_start = toPoint3d(desired_pose_);
         } else {
@@ -870,7 +870,7 @@ void Navigation::navigationRoutine(void) {
         octomap::point3d planning_goal  = toPoint3d(current_goal_);
 
         std::pair<std::vector<octomap::point3d>, PlanningResult> waypoints =
-            planner.findPath(planning_start, planning_goal, octree_, planning_timeout_, std::bind(&Navigation::visualizeTree, this, _1),
+            planner.findPath(planning_start, planning_goal, pos_cmd, octree_, planning_timeout_, std::bind(&Navigation::visualizeTree, this, _1),
                              std::bind(&Navigation::visualizeExpansions, this, _1, _2, _3));
 
         RCLCPP_INFO(this->get_logger(), "[%s]: Planner returned %ld waypoints, before resampling:", this->get_name(), waypoints.first.size());

--- a/src/navigation.cpp
+++ b/src/navigation.cpp
@@ -860,11 +860,11 @@ void Navigation::navigationRoutine(void) {
 
         octomap::point3d planning_start = toPoint3d(uav_pos_);
         //octomap::point3d pos_cmd        = toPoint3d(desired_pose_);
-        if ((desired_pose_.head<3>() - uav_pos_.head<3>()).norm() <= navigation_tolerance_) {
+        /*if ((desired_pose_.head<3>() - uav_pos_.head<3>()).norm() <= navigation_tolerance_) {
           planning_start = toPoint3d(desired_pose_);
         } else {
           planning_start = toPoint3d(uav_pos_);
-        }
+        }*/
         octomap::point3d planning_goal  = toPoint3d(current_goal_);
 
         std::pair<std::vector<octomap::point3d>, PlanningResult> waypoints =

--- a/src/navigation.cpp
+++ b/src/navigation.cpp
@@ -840,8 +840,10 @@ void Navigation::navigationRoutine(void) {
         last_goal_    = current_goal_;
         current_goal_ = waypoint_in_buffer_[current_waypoint_id_];
 
-        RCLCPP_INFO(this->get_logger(), "[%s]: Waypoint [%.2f, %.2f, %.2f, %.2f] set as a next goal", this->get_name(), current_goal_[0], current_goal_[1],
-                    current_goal_[2], current_goal_[3]);
+        RCLCPP_INFO(this->get_logger(), "[%s]: Waypoint [%.2f, %.2f, %.2f, %.2f] set as a next goal", this->get_name(), 
+                                          current_goal_[0], current_goal_[1], current_goal_[2], current_goal_[3]);
+        RCLCPP_INFO(this->get_logger(), "[%s]: Last received desired pose [%.2f, %.2f, %.2f, %.2f]", this->get_name(),
+                                          desired_pose_[0], desired_pose_[1], desired_pose_[2], desired_pose_[3]);            
 
         visualizeGoals(waypoint_in_buffer_);
 
@@ -871,8 +873,11 @@ void Navigation::navigationRoutine(void) {
             planner.findPath(planning_start, planning_goal, octree_, planning_timeout_, std::bind(&Navigation::visualizeTree, this, _1),
                              std::bind(&Navigation::visualizeExpansions, this, _1, _2, _3));
 
-        RCLCPP_INFO(this->get_logger(), "[%s]: Planner returned %ld waypoints", this->get_name(), waypoints.first.size());
+        RCLCPP_INFO(this->get_logger(), "[%s]: Planner returned %ld waypoints, before resampling:", this->get_name(), waypoints.first.size());
 
+        for (auto &w :waypoints.first) {
+          RCLCPP_INFO(this->get_logger(), "[%s]:        %.2f, %.2f, %.2f", this->get_name(), w.x(), w.y(), w.z());
+        }
         /* GOAL_REACHED //{ */
         if (waypoints.second == GOAL_REACHED) {
           RCLCPP_INFO(this->get_logger(), "[%s]: Current goal reached", this->get_name());


### PR DESCRIPTION
When planning takes more than the navigation routine loop, the updated control interface diagnostics message does not arrive before the next loop. When the next routine begins, state changes from MOVING to PLANNING directly since the mission finished flag has not yet changed. 
This fix adds a flag that is set to FALSE after the service request call to control_interface. In the next routine loop, it checks this flag if the diagnostics message from control interface has been received. It prevents the PLANNING->COMMANDING->MOVING->PLANNING loop, which happens in less than 1 second. If the control diagnostics messages was not received, it skips the mission completion checking in MOVING state for the current loop. 

Also, the extra altitude added for the vertical motion. When the upper layers are not existent in the octomap, the path planner tries to avoid the unknown space and the generated path is incorrect, often goes sideways of the waypoint. By adding extra motion of `planning_tree_resolution`, the upper layers are now scanned, and the path goes directly to the waypoint.